### PR TITLE
Localforage key fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
 module.exports = exports = function(grunt) {
     'use strict';
 
+    var pkg = grunt.file.readJSON('package.json');
+
     grunt.initConfig({
         concat: {
             options: {
@@ -13,7 +15,7 @@ module.exports = exports = function(grunt) {
                     banner:
                         '/*!\n' +
                         '    localForage Backbone Adapter\n' +
-                        '    Version 0.4.0\n' +
+                        '    Version ' + pkg.version + '\n' +
                         '    https://github.com/mozilla/localforage-backbone\n' +
                         '    (c) 2014 Mozilla, Apache License 2.0\n' +
                         '*/\n'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,14 +44,25 @@ module.exports = exports = function(grunt) {
                     ]
                 }
             }
+        },
+        watch: {
+            src: {
+                files: 'src/**/*.js',
+                tasks: ['test']
+            },
+            test: {
+                files: 'test/**/*.js',
+                tasks: ['jasmine']
+            }
         }
     });
 
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-jasmine');
     grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 
-    grunt.registerTask('default', ['build']);
+    grunt.registerTask('default', ['build', 'watch']);
     grunt.registerTask('build', ['concat', 'uglify']);
 
     grunt.registerTask('test', ['build', 'jasmine']);

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ models so they're saved to localForage instead of a REST server. Simply
 override your objects' `sync()` method with the namespace for your model:
 
 ```javascript
-    var MyModel = Backbone.Collection.extend({
+    var MyModel = Backbone.Model.extend({
         sync: Backbone.localforage.sync('MyModel')
     });
+
     var MyCollection = Backbone.Collection.extend({
         model: MyModel,
         sync: Backbone.localforage.sync('MyCollection')

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -6,8 +6,8 @@
     <script src="../bower_components/jquery/dist/jquery.js"></script>
     <script src="../bower_components/underscore/underscore.js"></script>
     <script src="../bower_components/backbone/backbone.js"></script>
-    <script src="../bower_components/localforage/localforage.js"></script>
-    <script src="../dist/localforage.backbone.js"></script> 
+    <script src="../bower_components/localforage/dist/localforage.js"></script>
+    <script src="../dist/localforage.backbone.js"></script>
   </head>
   <body>
     <script type="template/form" id="formtpl">

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-contrib-concat": "^0.3.0",
+    "grunt-contrib-jasmine": "^0.6.1",
     "grunt-contrib-uglify": "^0.4.0",
-    "grunt-contrib-jasmine": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1"
   },
   "browser": "dist/localforage.backbone.js",
   "main": "dist/localforage.backbone.js",

--- a/src/localforage.backbone.js
+++ b/src/localforage.backbone.js
@@ -60,8 +60,8 @@
                     }
                 } else { // `this` is a `Backbone.Model` if not a `Backbone.Collection`.
                     // Generate an id if one is not set yet.
-                    if (!model.id) {
-                        model[this.idAttribute] = model.attributes[this.idAttribute] = guid();
+                    if (!this.id) {
+                        this[this.idAttribute] = this.attributes[this.idAttribute] = guid();
                     }
 
                     // add a localforageKey for this model

--- a/src/localforage.backbone.js
+++ b/src/localforage.backbone.js
@@ -55,8 +55,8 @@
                 if (this instanceof Backbone.Collection) {
                     // If there's no localforageKey for this collection, create
                     // it.
-                    if (!this.sync.localforageKey) {
-                        this.sync.localforageKey = name;
+                    if (!this.localforageKey) {
+                        this.localforageKey = name;
                     }
                 } else { // `this` is a `Backbone.Model` if not a `Backbone.Collection`.
                     // Generate an id if one is not set yet.
@@ -64,9 +64,9 @@
                         model[this.idAttribute] = model.attributes[this.idAttribute] = guid();
                     }
 
-                    // If there's no localforageKey for this model create it
-                    if (!model.sync.localforageKey) {
-                        model.sync.localforageKey = name + "/" + model.id;
+                    // add a localforageKey for this model
+                    if (!this.localforageKey) {
+                      this.localforageKey = name + "/" + this.id;
                     }
                 }
                 switch (method) {
@@ -89,7 +89,7 @@
         },
 
         save: function(model, callback) {
-            localforage.setItem(model.sync.localforageKey, model.toJSON(), function(err, data) {
+            localforage.setItem(model.localforageKey, model.toJSON(), function(err, data) {
                 // If this model has a collection, keep the collection in =
                 // sync as well.
                 if (model.collection) {
@@ -104,7 +104,7 @@
                     callback = callback ? _.partial(callback, err, data) : void 0;
 
                     // Persist `model.collection` models' ids.
-                    localforage.setItem(model.collection.sync.localforageKey, collectionData, callback);
+                    localforage.setItem(model.collection.localforageKey, collectionData, callback);
                 } else if (callback) {
                     callback(data);
                 }
@@ -126,7 +126,7 @@
         },
 
         find: function(model, callbacks) {
-            localforage.getItem(model.sync.localforageKey, function(err, data) {
+            localforage.getItem(model.localforageKey, function(err, data) {
                 if (!err && !_.isEmpty(data)) {
                     if (callbacks.success) {
                         callbacks.success(data);
@@ -139,7 +139,7 @@
 
         // Only used by `Backbone.Collection#sync`.
         findAll: function(collection, callbacks) {
-            localforage.getItem(collection.sync.localforageKey, function(err, data) {
+            localforage.getItem(collection.localforageKey, function(err, data) {
                 if (!err && data && data.length) {
                     var done = function () {
                         if (callbacks.success) {
@@ -169,7 +169,7 @@
         },
 
         destroy: function(model, callbacks) {
-            localforage.removeItem(model.sync.localforageKey, function() {
+            localforage.removeItem(model.localforageKey, function() {
                 var json = model.toJSON();
                 if (callbacks.success) {
                     callbacks.success(json);

--- a/test/backbone.model.js
+++ b/test/backbone.model.js
@@ -6,69 +6,71 @@ describe('Backbone.Model', function () {
       sync: Backbone.localforage.sync('ModelNamespace')
     });
 
-    var model;
-    var id;
+    describe('Model flow', function () {
+        var model;
+        var id;
 
-    beforeEach(function(done) {
-        model = new Model();
-        if (id) {
-          model.set('id', id).fetch({
-            success: function() {
+        beforeEach(function(done) {
+            model = new Model();
+            if (id) {
+              model.set('id', id).fetch({
+                success: function() {
+                  done();
+                }
+              });
+            } else {
               done();
             }
-          });
-        } else {
-          done();
-        }
-    });
-
-    it('saves to localForage', function(done) {
-        model.save({hello: 'world!'}, {
-            success: function(model) {
-                id = model.get('id');
-
-                expect(model).toBeDefined();
-                expect(id).toBeDefined();
-                expect(model.get('hello')).toEqual('world!');
-
-                done();
-            }
         });
-    });
 
-    it('fetches from localForage', function(done) {
-        model.fetch({
-            success: function () {
-                expect(model).toBeDefined();
-                expect(model.attributes).toEqual({
-                    id: id,
-                    hello: 'world!'
-                });
+        it('saves to localForage', function(done) {
+            model.save({hello: 'world!'}, {
+                success: function(model) {
+                    id = model.get('id');
 
-                done();
-            }
-        });
-    });
+                    expect(model).toBeDefined();
+                    expect(id).toBeDefined();
+                    expect(model.get('hello')).toEqual('world!');
 
-    it('updates to localForage', function(done) {
-        model.save({hello: 'you!'}, {
-            success: function() {
-                expect(model.get('hello')).toEqual('you!');
-
-                done();
-            }
-        });
-    });
-
-    it('removes from localForage', function(done) {
-        model.destroy({
-            success: function() {
-                model.fetch({
-                  error: function () {
                     done();
-                  }
-                });
-            }
+                }
+            });
+        });
+
+        it('fetches from localForage', function(done) {
+            model.fetch({
+                success: function () {
+                    expect(model).toBeDefined();
+                    expect(model.attributes).toEqual({
+                        id: id,
+                        hello: 'world!'
+                    });
+
+                    done();
+                }
+            });
+        });
+
+        it('updates to localForage', function(done) {
+            model.save({hello: 'you!'}, {
+                success: function() {
+                    expect(model.get('hello')).toEqual('you!');
+
+                    done();
+                }
+            });
+        });
+
+        it('removes from localForage', function(done) {
+            model.destroy({
+                success: function() {
+                    model.fetch({
+                      error: function () {
+                        done();
+                      }
+                    });
+                }
+            });
         });
     });
 });

--- a/test/backbone.model.js
+++ b/test/backbone.model.js
@@ -73,4 +73,35 @@ describe('Backbone.Model', function () {
             });
         });
     });
+
+    describe('test', function () {
+        it('should create distinct key', function (done) {
+            var model1 = new Model();
+            var model2 = new Model();
+
+            var ids = [];
+            // trick to faint asynchronicity of the test
+            var updateTest = function (value) {
+                ids.push(value);
+
+                // mark test as complete
+                if (ids.length > 1) {
+                    expect(ids[0]).not.toEqual(ids[1]);
+                    done();
+                }
+            };
+
+            model1.fetch({
+                error: function () {
+                    updateTest(model1.id);
+                }
+            });
+
+            model2.fetch({
+                error: function () {
+                    updateTest(model2.id);
+                }
+            });
+        })
+    });
 });


### PR DESCRIPTION
This is fix #9.
This should not be BC, as the `localeforageKey` is now added to the context instance. The `model.sync` being a function it is better IMO, to set the `localeforageKey` on the instance itself.

before:  `model.sync.localeforageKey`
after: `model.localeforageKey`

Test added.

This PR is based on my other PR #13.