### PR TITLE
bump underscore to 1.8.3 and backbone to 1.2.1 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,8 @@
   ],
   "dependencies": {
     "localforage": "^1.2.0",
-    "backbone": "~1.1.2",
-    "underscore": "~1.6.0"
+    "backbone": "~1.2.1",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "jquery": "~2.1.0",

--- a/examples/main.js
+++ b/examples/main.js
@@ -87,36 +87,36 @@
     });
 
     var ListView = Backbone.View.extend({
-      tagName: 'ul',
-      className: 'table-view',
+        tagName: 'ul',
+        className: 'table-view',
 
-      initialize: function() {
-          this.listenTo(this.collection, 'add', this.addItemView);
-          this.listenTo(this.collection, 'remove', this.removeItem);
-          this.listenTo(this.collection, 'reset', this.reset);
-          this._itemsView = {};
-      },
+        initialize: function() {
+            this.listenTo(this.collection, 'add', this.addItemView);
+            this.listenTo(this.collection, 'remove', this.removeItem);
+            this.listenTo(this.collection, 'reset', this.reset);
+            this._itemsView = {};
+        },
 
-      addItemView: function(model) {
-          var itemView = new ItemView({model: model});
-          this.$el.append(itemView.render().el);
-          this._itemsView[model.id] = itemView;
-      },
+        addItemView: function(model) {
+            var itemView = new ItemView({model: model});
+            this.$el.append(itemView.render().el);
+            this._itemsView[model.id] = itemView;
+        },
 
-      removeItem: function(model) {
-          this._itemsView[model.id].remove();
-          this._itemsView[model.id] = null;
-          delete this._itemsView[model.id];
-      },
+        removeItem: function(model) {
+            this._itemsView[model.id].remove();
+            this._itemsView[model.id] = null;
+            delete this._itemsView[model.id];
+        },
 
-      reset: function(model, options) {
-          options.previousModels.map(this.removeItem, this);
-      },
+        reset: function(model, options) {
+            options.previousModels.map(this.removeItem, this);
+        },
 
-      render: function() {
-          this.collection.map(this.addItemView, this);
-          return this;
-      }
+        render: function() {
+            this.collection.map(this.addItemView, this);
+            return this;
+        }
     });
 
     var ItemView = Backbone.View.extend({


### PR DESCRIPTION
In my "backbone + marionette + localforage" setup, which uses bower, on install, Bower gets some version mismatch for Underscore:

Unable to find a suitable version for underscore, please choose one:
    1) underscore#~1.6.0 which resolved to 1.6.0 and is required by localforage-backbone#0.6.1
    2) underscore#1.4.4 - 1.8.3 which resolved to 1.8.3 and is required by backbone.radio#0.9.1, marionette#2.4.2
    3) underscore#>=1.4.0 <=1.8.3 which resolved to 1.8.3 and is required by backbone.babysitter#0.1.8
    4) underscore#>=1.3.3 <=1.8.3 which resolved to 1.8.3 and is required by backbone.wreqr#1.3.3
    5) underscore#>=1.5.0 which resolved to 1.8.3 and is required by backbone#1.1.2
    6) underscore#>=1.7.0 which resolved to 1.8.3 and is required by backbone#1.2.1

Every lib in the setup requires Underscore 1.8.3, apart from localForage-backbone, which still wants 1.6.0.  Then, I also bumped Backbone to its latest version 1.2.1
